### PR TITLE
Fixed link to preview page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kakaroto
 
-[kakaro.to](kakaro.to)
+[kakaro.to](https://kakaro.to/)
 
 ## TODO
 


### PR DESCRIPTION
Fixed the link to the preview page. It used to point to a (non-existant) file.